### PR TITLE
utilize mutation to persist journeys

### DIFF
--- a/src/components/add-journey/SearchButton.tsx
+++ b/src/components/add-journey/SearchButton.tsx
@@ -12,28 +12,35 @@ type Props = {
 };
 
 export const SearchButton: React.FC<Props> = ({ departureTime, departureStation, arrivalStation }) => {
-  const { isFetching } = useGetJourneys();
+  const { isLoading, mutateAsync } = useGetJourneys();
   const t = useTranslations();
 
   const setDepartureTime = useJourneySearchStore((state) => state.setDepartureTime);
   const setDepartureStation = useJourneySearchStore((state) => state.setDepartureStation);
   const setArrivalStation = useJourneySearchStore((state) => state.setArrivalStation);
+  const setJourneys = useJourneySearchStore((state) => state.setJourneys);
 
   return (
     <div className="mt-1 flex w-full items-end">
       <button
         onClick={() => {
-          setDepartureTime(departureTime);
-          if (departureStation) {
+          if (departureStation && arrivalStation) {
+            setDepartureTime(departureTime);
             setDepartureStation(departureStation);
-          }
-          if (arrivalStation) {
             setArrivalStation(arrivalStation);
+            mutateAsync(
+              { departureStation, arrivalStation, departureTime },
+              {
+                onSuccess: (res) => {
+                  setJourneys(res);
+                },
+              }
+            );
           }
         }}
         className="flex w-full justify-center rounded-md border border-transparent bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
       >
-        {isFetching ? <LoadingSpinner /> : t('add.search')}
+        {isLoading ? <LoadingSpinner /> : t('add.search')}
       </button>
     </div>
   );

--- a/src/hooks/useGetJourneys.ts
+++ b/src/hooks/useGetJourneys.ts
@@ -2,8 +2,8 @@ import axios from 'axios';
 import toast from 'react-hot-toast';
 import { TRANSPORT_API_URL } from '@/constants';
 import type { Journey, Station } from '@/types/opendata';
-import { useQuery } from '@tanstack/react-query';
-import { useJourneySearchStore } from './useJourneySearchStore';
+import { useMutation } from '@tanstack/react-query';
+// import { useJourneySearchStore } from './useJourneySearchStore';
 
 const getJourneys = ({
   departureStation,
@@ -22,25 +22,23 @@ const getJourneys = ({
 };
 
 export const useGetJourneys = () => {
-  const setJourneys = useJourneySearchStore((state) => state.setJourneys);
-  const departureTime = useJourneySearchStore((state) => state.departureTime);
-  const departureStation = useJourneySearchStore((state) => state.departureStation);
-  const arrivalStation = useJourneySearchStore((state) => state.arrivalStation);
+  // const departureStation = useJourneySearchStore((state) => state.departureStation);
+  // const arrivalStation = useJourneySearchStore((state) => state.arrivalStation);
 
-  return useQuery(
-    ['transportApi', departureStation, arrivalStation, departureTime],
-    () => {
-      return getJourneys({ departureStation, arrivalStation, departureTime });
+  return useMutation({
+    mutationFn: async ({
+      departureStation,
+      arrivalStation,
+      departureTime,
+    }: {
+      readonly departureStation?: Station;
+      readonly arrivalStation?: Station;
+      readonly departureTime: string;
+    }) => {
+      return getJourneys({ departureStation, arrivalStation, departureTime }).then((res) => res.data.connections);
     },
-    {
-      onSuccess: (res) => {
-        setJourneys(res.data.connections);
-      },
-      onError: () => {
-        toast.error('Unable to load journeys');
-      },
-      enabled: !!departureTime && !!departureStation && !!arrivalStation,
-      refetchOnWindowFocus: false,
-    }
-  );
+    onError: () => {
+      toast.error('Unable to load journeys');
+    },
+  });
 };

--- a/src/hooks/useGetJourneys.ts
+++ b/src/hooks/useGetJourneys.ts
@@ -3,7 +3,6 @@ import toast from 'react-hot-toast';
 import { TRANSPORT_API_URL } from '@/constants';
 import type { Journey, Station } from '@/types/opendata';
 import { useMutation } from '@tanstack/react-query';
-// import { useJourneySearchStore } from './useJourneySearchStore';
 
 const getJourneys = ({
   departureStation,
@@ -22,9 +21,6 @@ const getJourneys = ({
 };
 
 export const useGetJourneys = () => {
-  // const departureStation = useJourneySearchStore((state) => state.departureStation);
-  // const arrivalStation = useJourneySearchStore((state) => state.arrivalStation);
-
   return useMutation({
     mutationFn: async ({
       departureStation,


### PR DESCRIPTION
Changing `useQuery` hook to `useMutation` hook to be able to solve for persisting journeys to solve https://github.com/noahflk/railtrack/issues/69

Wrote in logic to aggregate together 2 sets of journeys and sort them as well as logic to grab the earliest/latest timestamps.